### PR TITLE
feat: LDAP downsync, full-text search & archive retention automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Document editing and file sync:
 | `ARCHIVE_MYSQL_USER` | MySQL user for Archive |
 | `ARCHIVE_MYSQL_PASS` | MySQL password for Archive |
 | `ARCHIVE_MYSQL_DB` | MySQL database for Archive |
+| `ARCHIVE_RETENTION_DAYS` | Mail retention in days (`default_retention_days` in `grommunio-archive.conf`). The daily housekeeping purges mail older than this. Only applies to newly archived mail. Default: `3650` (10 years) |
 | `ARCHIVE_INDEXER_DELTA_INTERVAL` | Sphinx delta indexer interval (sleep-compatible format, e.g. `600`, `10m`, `1h`). Default: `10m` |
 | `ARCHIVE_INDEXER_MAIN_INTERVAL` | Interval between daily housekeeping runs (main merge, attachments, purge, sign, stats, daily-report). Default: `24h` |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ volumes:
   files_mysql_data:
   office_mysql_data:
   archive_mysql_data:
+  archive_data:
+  archive_config:
   grommunio_admin_api:
   grommunio_antispam:
   grommunio_dav:
@@ -218,6 +220,8 @@ services:
       - opensuse_data:/data
       - variables_data:/home/vars
       - cert_data:/etc/grommunio-common/ssl
+      - archive_data:/var/lib/grommunio-archive
+      - archive_config:/etc/grommunio-archive
     expose:
       - "8443"   # HTTPS (nginx)
       - "2693"   # Archive SMTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ volumes:
   archive_data:
   archive_config:
   grommunio_admin_api:
+  grommunio_admin_license:
   grommunio_antispam:
   grommunio_dav:
   grommunio_web:
@@ -173,6 +174,7 @@ services:
       - cert_data:/etc/grommunio-common/ssl
       - gromox_services:/home/gromox-services
       - grommunio_admin_api:/var/lib/grommunio-admin-api
+      - grommunio_admin_license:/etc/grommunio-admin-common/license
       - grommunio_antispam:/var/lib/grommunio-antispam
       - grommunio_dav:/var/lib/grommunio-dav
       - grommunio_web:/var/lib/grommunio-web

--- a/gromox-archive/Dockerfile
+++ b/gromox-archive/Dockerfile
@@ -36,13 +36,13 @@ RUN	curl https://download.grommunio.com/RPM-GPG-KEY-grommunio > gr.key && \
 
 # Install grommunio packages (retry up to 3 times for transient download errors)
 RUN    zypper --non-interactive install -y vim mysql \
-         php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common \
+         php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common php8-iconv php8-ctype \
        || { echo "Retry 1..."; zypper clean -a; sleep 5; \
             zypper --non-interactive install -y vim mysql \
-              php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common; } \
+              php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common php8-iconv php8-ctype; } \
        || { echo "Retry 2..."; zypper clean -a; sleep 10; \
             zypper --non-interactive install -y vim mysql \
-              php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common; }
+              php8-mysql php8-cli php8-openssl php-fpm php-gd grommunio-archive sphinx nginx jq cyrus-sasl-saslauthd cyrus-sasl-plain grommunio-common php8-iconv php8-ctype; }
 
 # Install supervisord (Python 3.13 is the system default on openSUSE Leap 16)
 RUN zypper -n install -y python313-pip && \

--- a/gromox-archive/entrypoint.sh
+++ b/gromox-archive/entrypoint.sh
@@ -87,6 +87,12 @@ if [[ $INSTALLVALUE == *"archive"* ]] ; then
   setconf /etc/grommunio-archive/grommunio-archive.conf mysqlhost "${ARCHIVE_MYSQL_HOST}" 0
   setconf /etc/grommunio-archive/grommunio-archive.conf listen_addr 0.0.0.0 0
 
+  # Enforce mail retention (in days; default 10 years). piler stamps the retention
+  # value onto each mail at store time, so this only affects newly archived mail —
+  # it does not extend or shorten the retention of mail already in the archive.
+  ARCHIVE_RETENTION_DAYS="${ARCHIVE_RETENTION_DAYS:-3650}"
+  setconf /etc/grommunio-archive/grommunio-archive.conf default_retention_days "${ARCHIVE_RETENTION_DAYS}" 0
+
   php /etc/grommunio-archive/sphinx.conf.dist > /etc/sphinx/sphinx.conf
   sed -i -e "s/MYSQL_HOSTNAME/${ARCHIVE_MYSQL_HOST}/" -e "s/MYSQL_DATABASE/${ARCHIVE_MYSQL_DB}/" -e "s/MYSQL_PASSWORD/${ARCHIVE_MYSQL_PASS}/" -e "s/MYSQL_USERNAME/${ARCHIVE_MYSQL_USER}/" /etc/sphinx/sphinx.conf
   chown groarchive:sphinx /etc/sphinx/sphinx.conf

--- a/gromox-core/Dockerfile
+++ b/gromox-core/Dockerfile
@@ -70,6 +70,12 @@ RUN chmod +x /home/scripts/db.sh
 COPY gromox-core/entrypoint.sh /home/entrypoint.sh
 RUN chmod +x /home/entrypoint.sh
 
+# LDAP downsync automation (systemd timer). LDAP connections are configured
+# out-of-band via the admin API; this only automates the periodic downsync.
+COPY gromox-core/scripts/grommunio-ldap-sync.service /etc/systemd/system/grommunio-ldap-sync.service
+COPY gromox-core/scripts/grommunio-ldap-sync.timer /etc/systemd/system/grommunio-ldap-sync.timer
+RUN install -m 0755 /home/scripts/grommunio-ldap-sync /usr/local/sbin/grommunio-ldap-sync
+
 COPY gromox-core/docker-entrypoint.sh /home/docker-entrypoint.sh
 RUN chmod +x /home/docker-entrypoint.sh
 

--- a/gromox-core/Dockerfile
+++ b/gromox-core/Dockerfile
@@ -37,17 +37,17 @@ RUN	curl https://download.grommunio.com/RPM-GPG-KEY-grommunio > gr.key && \
 # Install grommunio packages (retry up to 3 times for transient download errors)
 RUN    zypper --non-interactive install -y vim mysql nginx \
          gromox grommunio-admin-api grommunio-admin-web grommunio-antispam \
-         grommunio-common grommunio-web grommunio-sync grommunio-dav postfix postfix-mysql \
+         grommunio-common grommunio-web grommunio-index grommunio-sync grommunio-dav postfix postfix-mysql \
          grommunio-chat grommunio-keycloak grommunio-auth cyrus-sasl-saslauthd cyrus-sasl-plain jq redis \
        || { echo "Retry 1..."; zypper clean -a; sleep 5; \
             zypper --non-interactive install -y vim mysql nginx \
               gromox grommunio-admin-api grommunio-admin-web grommunio-antispam \
-              grommunio-common grommunio-web grommunio-sync grommunio-dav postfix postfix-mysql \
+              grommunio-common grommunio-web grommunio-index grommunio-sync grommunio-dav postfix postfix-mysql \
               grommunio-chat grommunio-keycloak grommunio-auth cyrus-sasl-saslauthd cyrus-sasl-plain jq redis; } \
        || { echo "Retry 2..."; zypper clean -a; sleep 10; \
             zypper --non-interactive install -y vim mysql nginx \
               gromox grommunio-admin-api grommunio-admin-web grommunio-antispam \
-              grommunio-common grommunio-web grommunio-sync grommunio-dav postfix postfix-mysql \
+              grommunio-common grommunio-web grommunio-index grommunio-sync grommunio-dav postfix postfix-mysql \
               grommunio-chat grommunio-keycloak grommunio-auth cyrus-sasl-saslauthd cyrus-sasl-plain jq redis; }
 
 # Install Certbot from openSUSE 16 packages + iconv modules (iso-2022-jp etc.)

--- a/gromox-core/README.md
+++ b/gromox-core/README.md
@@ -74,3 +74,30 @@ docker exec gromox-core tail -f /var/log/supervisor-postfix-err.log
 docker exec gromox-core rm -f /etc/gromox/.setup/entry_done
 docker compose restart gromox-core
 ```
+
+### LDAP Sync
+
+Automates the periodic `grommunio-admin ldap downsync` across all organizations
+via a systemd timer. The LDAP connections themselves are configured out-of-band
+(admin API / web UI); this only schedules the recurring sync.
+
+| Variable | Description |
+|---|---|
+| `ENABLE_LDAP_SYNC` | Set to `true` to enable the periodic LDAP downsync timer |
+| `LDAP_SYNC_INTERVAL` | systemd `OnCalendar` expression for the interval (default: `*:0/15`, i.e. every 15 min) |
+
+Examples for `LDAP_SYNC_INTERVAL`:
+
+```
+*:0/15          # every 15 minutes (:00 :15 :30 :45)
+hourly          # every hour
+00/6:00         # every 6 hours
+*-*-* 02:00:00  # daily at 02:00
+```
+
+When enabled, the entrypoint writes a systemd drop-in override
+(`/etc/systemd/system/grommunio-ldap-sync.timer.d/override.conf`) with the given
+interval and enables the timer. When disabled (default), the timer is stopped and
+the override removed. Sync results are logged to journald under the
+`grommunio-ldap-sync` tag (`journalctl -t grommunio-ldap-sync`). If no LDAP is
+configured for an org, the sync logs `ERR_NO_LDAP` and makes no changes.

--- a/gromox-core/README.md
+++ b/gromox-core/README.md
@@ -101,3 +101,32 @@ interval and enables the timer. When disabled (default), the timer is stopped an
 the override removed. Sync results are logged to journald under the
 `grommunio-ldap-sync` tag (`journalctl -t grommunio-ldap-sync`). If no LDAP is
 configured for an org, the sync logs `ERR_NO_LDAP` and makes no changes.
+
+### Full-Text Search Index
+
+Webmail full-text search relies on per-user SQLite indexes built by
+`grommunio-index`. These indexes only exist once the tool has run against
+provisioned mailboxes, so the entrypoint builds them once on first setup and
+then refreshes them periodically via cron (`crond` runs under supervisord).
+`grommunio-index -A -c` processes all users and creates the index if missing,
+which also picks up newly created mailboxes.
+
+| Variable | Description |
+|---|---|
+| `ENABLE_INDEX` | Set to `false` to disable the periodic index refresh (default: `true`) |
+| `INDEX_SCHEDULE` | cron expression for the refresh interval (default: `0 * * * *`, i.e. hourly) |
+
+Examples for `INDEX_SCHEDULE`:
+
+```
+0 * * * *       # every hour
+*/30 * * * *    # every 30 minutes
+0 */6 * * *     # every 6 hours
+0 2 * * *       # daily at 02:00
+```
+
+When enabled (the default), the entrypoint runs an initial `grommunio-index -A -c`
+(logged to `${LOGFILE}`) and writes `/etc/cron.d/grommunio-index` for the
+recurring refresh (logged to `/var/log/grommunio-index.log`). When disabled, the
+cron file is removed. A build can be triggered manually at any time with
+`docker exec gromox-core grommunio-index -A -c`.

--- a/gromox-core/entrypoint.sh
+++ b/gromox-core/entrypoint.sh
@@ -423,6 +423,28 @@ if [[ $ENABLE_KEYCLOAK = true ]] ; then
 else
   rm -f /etc/gromox/keycloak.json /etc/gromox/oidc-import.json
 fi
+
+# grommunio LDAP downsync automation (systemd timer)
+# ENABLE_LDAP_SYNC=true|false  -> enable/disable the periodic sync
+# LDAP_SYNC_INTERVAL           -> systemd OnCalendar expression (default: every 15 min)
+#                                 e.g. "hourly", "*-*-* 02:00:00", "00/6:00"
+LDAP_SYNC_DROPIN="/etc/systemd/system/grommunio-ldap-sync.timer.d"
+if [[ $ENABLE_LDAP_SYNC = true ]] ; then
+  LDAP_SYNC_INTERVAL="${LDAP_SYNC_INTERVAL:-*:0/15}"
+  mkdir -p "${LDAP_SYNC_DROPIN}"
+  cat > "${LDAP_SYNC_DROPIN}/override.conf" <<EOF
+[Timer]
+OnCalendar=
+OnCalendar=${LDAP_SYNC_INTERVAL}
+EOF
+  systemctl daemon-reload
+  systemctl enable --now grommunio-ldap-sync.timer >>"${LOGFILE}" 2>&1
+else
+  systemctl disable --now grommunio-ldap-sync.timer >>"${LOGFILE}" 2>&1
+  rm -f "${LDAP_SYNC_DROPIN}/override.conf"
+  systemctl daemon-reload
+fi
+
 setup_done
 
 exit 0

--- a/gromox-core/entrypoint.sh
+++ b/gromox-core/entrypoint.sh
@@ -122,7 +122,7 @@ if [[ $INSTALLVALUE == *"chat"* ]] ; then
   generate_admin_chat_conf "/etc/grommunio-admin-api/conf.d/chat.yaml"
 
   chmod 640 ${CHAT_CONFIG}
-  jq '.chatWebAddress |= "https://'${FQDN}'/chat"' /tmp/config.json > /tmp/config-new.json
+  jq '.chatWebAddress |= "https://'${FQDN}'/chat/"' /tmp/config.json > /tmp/config-new.json
   mv /tmp/config-new.json /tmp/config.json
 
 fi
@@ -269,7 +269,7 @@ location ^~ /files {
 }
 EOF
 
-  jq '.fileWebAddress |= "https://'${FQDN}'/files"' /tmp/config.json > /tmp/config-new.json
+  jq '.fileWebAddress |= "https://'${FQDN}'/files/"' /tmp/config.json > /tmp/config-new.json
   mv /tmp/config-new.json /tmp/config.json
 fi
 
@@ -364,7 +364,7 @@ location ^~ /view {
 	access_log /var/log/nginx/nginx-archive-access.log;
 }
 EOF
-  jq '.archiveWebAddress |= "https://'${FQDN}'/archive"' /tmp/config.json > /tmp/config-new.json
+  jq '.archiveWebAddress |= "https://'${FQDN}'/archive/"' /tmp/config.json > /tmp/config-new.json
   mv /tmp/config-new.json /tmp/config.json
 
 fi
@@ -443,6 +443,24 @@ else
   systemctl disable --now grommunio-ldap-sync.timer >>"${LOGFILE}" 2>&1
   rm -f "${LDAP_SYNC_DROPIN}/override.conf"
   systemctl daemon-reload
+fi
+
+# grommunio full-text search index automation (cron)
+# Webmail full-text search needs per-user SQLite indexes built by
+# grommunio-index. These only exist once the tool has run against provisioned
+# mailboxes, so we build them once here and then refresh via cron (crond runs
+# under supervisord). `grommunio-index -A -c` = all users, create/keep current.
+# ENABLE_INDEX=true|false  -> enable/disable the periodic refresh (default: true)
+# INDEX_SCHEDULE           -> cron expression for the interval (default: hourly)
+if [[ ${ENABLE_INDEX:-true} = true ]] ; then
+  INDEX_SCHEDULE="${INDEX_SCHEDULE:-0 * * * *}"
+  echo "${INDEX_SCHEDULE} root grommunio-index -A -c >> /var/log/grommunio-index.log 2>&1" \
+    > /etc/cron.d/grommunio-index
+  # Build the indexes right away so search works without waiting for the first
+  # cron tick.
+  grommunio-index -A -c >>"${LOGFILE}" 2>&1
+else
+  rm -f /etc/cron.d/grommunio-index
 fi
 
 setup_done

--- a/gromox-core/scripts/grommunio-ldap-sync
+++ b/gromox-core/scripts/grommunio-ldap-sync
@@ -1,0 +1,53 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Periodically downsync all organizations from their configured LDAP source.
+# LDAP connections themselves are configured out-of-band (via the admin API /
+# ldap.yaml); this only automates `grommunio-admin ldap downsync` per org.
+#set -e
+orgs=$(grommunio-admin domain query --format=csv orgID 2>/dev/null | \
+    uniq | sed '/^orgID/d;s/\r/ /g');
+_logger() { logger -p "$PRIO" -t grommunio-ldap-sync "$*" ; }
+if [ -n "$orgs" ]; then
+    for org in $orgs; do
+        orgname=$(grommunio-admin org query --filter ID="$org" name)
+        grommunio-admin ldap downsync --complete --organization "$org"
+        ret=$?
+        RUNCHECK=true
+        case "$ret" in
+            0)  PRIO=6; STATUS=SUCCESS;
+                NOTICE="OK"; RUNCHECK=false;;
+            1)  PRIO=4; STATUS=ERR_DECLINE;
+                NOTICE="User declined prompt";;
+            2)  PRIO=4; STATUS=ERR_USR_ABRT;
+                NOTICE="User aborted";;
+            3)  PRIO=4; STATUS=ERR_NO_LDAP;
+                NOTICE="LDAP not available";;
+            4)  PRIO=4; STATUS=ERR_GENERIC;
+                NOTICE="Something went wrong";;
+            5)  PRIO=4; STATUS=ERR_NO_USER;
+                NOTICE="LDAP User not found";;
+            6)  PRIO=4; STATUS=ERR_AMBIG;
+                NOTICE="Request was ambiguous";;
+            7)  PRIO=4; STATUS=ERR_DB;
+                NOTICE="Error occurred when communicating with the database";;
+            8)  PRIO=4; STATUS=ERR_CONFLICT;
+                NOTICE="Target DB user is associated with another LDAP object";;
+            9)  PRIO=4; STATUS=ERR_COMMIT;
+                NOTICE="Error during database commit";;
+            10) PRIO=4; STATUS=ERR_INVALID_DATA;
+                NOTICE="User data check failed";;
+            11) PRIO=4; STATUS=ERR_SETUP;
+                NOTICE="Error during user setup";;
+            12) PRIO=4; STATUS=ERR_PARTIAL;
+                NOTICE="Some user failed to synchronize";;
+            *)  PRIO=3; STATUS=ERR_UNKNOWN;
+                NOTICE="unknown return status";;
+        esac
+        logger -p "$PRIO" -t grommunio-ldap-sync \
+            "[${ret}:${STATUS}] orgID:${org} orgName:${orgname} - ${NOTICE}"
+        if $RUNCHECK; then
+            grommunio-admin ldap check --organization "$org" | \
+                logger -p "$PRIO" -t grommunio-ldap-sync
+        fi
+    done
+fi

--- a/gromox-core/scripts/grommunio-ldap-sync.service
+++ b/gromox-core/scripts/grommunio-ldap-sync.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Grommunio LDAP Sync
+
+[Service]
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
+Type=oneshot
+Environment=SYSTEMD=true
+ExecStart=/usr/local/sbin/grommunio-ldap-sync

--- a/gromox-core/scripts/grommunio-ldap-sync.timer
+++ b/gromox-core/scripts/grommunio-ldap-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Grommunio LDAP Sync
+
+[Timer]
+OnCalendar=00/3:05
+AccuracySec=5m
+Persistent=true
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

This PR bundles several independent improvements to the gromox-core and gromox-archive containers: automated LDAP downsync, webmail full-text search, configurable archive retention, and a set of packaging/URL fixes.

Fixes #32, #33, #34.

## LDAP downsync automation

Automates the periodic `grommunio-admin ldap downsync` across all orgs via a systemd timer. LDAP connections are still configured out-of-band; this only schedules the recurring sync. Disabled by default.

**Changes**
- Add `grommunio-ldap-sync` script + systemd `.service`/`.timer` units
- `Dockerfile`: install units and script into the image
- `entrypoint.sh`: on `ENABLE_LDAP_SYNC=true`, write a timer drop-in with the chosen interval and enable it; otherwise stop/remove it
- `README.md`: document the new env vars

**Config**

| Variable | Description |
|---|---|
| `ENABLE_LDAP_SYNC` | `true` enables the downsync timer (default: off) |
| `LDAP_SYNC_INTERVAL` | systemd `OnCalendar` expr (default: `*:0/15`, every 15 min) |

Source / Inspired by: https://github.com/crpb/grommunio/tree/main/enhancements/grommunio-ldap-sync

## Full-text search index automation (fixes #34)

Webmail full-text search relies on per-user SQLite indexes built by `grommunio-index`, which was previously missing from the image. This adds the package and automates index builds.

**Changes**
- `Dockerfile`: add the `grommunio-index` package
- `entrypoint.sh`: build indexes once on first setup (`grommunio-index -A -c`) and refresh`crond` under supervisord); newly created mailboxes are picked up automatically
- `README.md`: document the new env vars

**Config**

| Variable | Description |
|---|---|
| `ENABLE_INDEX` | `false` disables the periodic index refresh (default: `true`) |
| `INDEX_SCHEDULE` | cron expression for the refresh interval (default: `0 * * * *`, hourly) |
                                                                                                                                                                                                              
 ## Archive retention + fixes (fixes #32)

**Changes**
- `entrypoint.sh` (archive): set `default_retention_days` via `ARCHIVE_RETENTION_DAYS`. piler stamps the retention value onto each mail at store time, so this only affects newly archived mail — it does not extend or shorten retention of mail already in the archive
- `docker-compose.yml`: persist archive data/config with dedicated `archive_data`/`archive_config` volumes
- `Dockerfile` (archive): add `php8-iconv` and `php8-ctype` — fixes HTTP 500 on viewing archived messages caused by missing `iconv_mime_decode()`/`ctype_space()`
- `README.md`: document `ARCHIVE_RETENTION_DAYS`

**Config**

| Variable | Description |
|---|---|
| `ARCHIVE_RETENTION_DAYS` | Mail retention in days (`default_retention_days`); daily houspplies to newly archived mail only. Default: `3650` (10 years) |

## URL fix (fixes #33)

Chat, Files and Archive web addresses are now generated with trailing slashes (`/chat/`, `/files/`, `/archive/`) to prevent reverse-proxy redirects from routing to internal ports.